### PR TITLE
fix: Make GitHub env variables optional for preview environments

### DIFF
--- a/src/app/projects/[id]/generate/components/RemotionPreview.tsx
+++ b/src/app/projects/[id]/generate/components/RemotionPreview.tsx
@@ -194,7 +194,7 @@ export default function RemotionPreview({
             doubleClickToFullscreen
             clickToPlay
             loop={loop}
-            autoPlay={false}
+            autoPlay={true}
             playbackRate={playbackRate}
             initiallyMuted={false}
             inFrame={inFrame}

--- a/src/env.js
+++ b/src/env.js
@@ -37,22 +37,12 @@ export const env = createEnv({
     STRIPE_SECRET_KEY: z.string().min(1),
     STRIPE_WEBHOOK_SECRET: z.string().min(1),
 
-    // GitHub App (repo access) - Optional in non-production
-    GITHUB_APP_ID: process.env.NODE_ENV === "production" 
-      ? z.string().min(1) 
-      : z.string().optional(),
-    GITHUB_CLIENT_ID: process.env.NODE_ENV === "production"
-      ? z.string().min(1)
-      : z.string().optional(),
-    GITHUB_CLIENT_SECRET: process.env.NODE_ENV === "production"
-      ? z.string().min(1)
-      : z.string().optional(),
-    GITHUB_APP_PRIVATE_KEY: process.env.NODE_ENV === "production"
-      ? z.string().min(1)
-      : z.string().optional(),
-    GITHUB_WEBHOOK_SECRET: process.env.NODE_ENV === "production"
-      ? z.string().min(1)
-      : z.string().optional(),
+    // GitHub App (repo access) - Optional in preview/dev environments
+    GITHUB_APP_ID: z.string().optional(),
+    GITHUB_CLIENT_ID: z.string().optional(),
+    GITHUB_CLIENT_SECRET: z.string().optional(),
+    GITHUB_APP_PRIVATE_KEY: z.string().optional(),
+    GITHUB_WEBHOOK_SECRET: z.string().optional(),
 
     // Worker Configuration (Server-side)
     WORKER_POLLING_INTERVAL: z.preprocess(

--- a/src/env.js
+++ b/src/env.js
@@ -37,12 +37,22 @@ export const env = createEnv({
     STRIPE_SECRET_KEY: z.string().min(1),
     STRIPE_WEBHOOK_SECRET: z.string().min(1),
 
-    // GitHub App (repo access)
-    GITHUB_APP_ID: z.string().min(1),
-    GITHUB_CLIENT_ID: z.string().min(1),
-    GITHUB_CLIENT_SECRET: z.string().min(1),
-    GITHUB_APP_PRIVATE_KEY: z.string().min(1),
-    GITHUB_WEBHOOK_SECRET: z.string().min(1),
+    // GitHub App (repo access) - Optional in non-production
+    GITHUB_APP_ID: process.env.NODE_ENV === "production" 
+      ? z.string().min(1) 
+      : z.string().optional(),
+    GITHUB_CLIENT_ID: process.env.NODE_ENV === "production"
+      ? z.string().min(1)
+      : z.string().optional(),
+    GITHUB_CLIENT_SECRET: process.env.NODE_ENV === "production"
+      ? z.string().min(1)
+      : z.string().optional(),
+    GITHUB_APP_PRIVATE_KEY: process.env.NODE_ENV === "production"
+      ? z.string().min(1)
+      : z.string().optional(),
+    GITHUB_WEBHOOK_SECRET: process.env.NODE_ENV === "production"
+      ? z.string().min(1)
+      : z.string().optional(),
 
     // Worker Configuration (Server-side)
     WORKER_POLLING_INTERVAL: z.preprocess(


### PR DESCRIPTION
- GitHub integration variables now only required in production
- Allows Preview/Dev deployments without GitHub app configuration
- Fixes Vercel Preview build failures