### PR TITLE
fix(auto-fix): improve scene targeting and context for reliable error…

### DIFF
--- a/src/app/projects/[id]/generate/workspace/panels/TimelinePanel.tsx
+++ b/src/app/projects/[id]/generate/workspace/panels/TimelinePanel.tsx
@@ -67,7 +67,7 @@ interface TimelinePanelProps {
 }
 
 interface DragInfo {
-  action: 'move' | 'resize-start' | 'resize-end' | 'playhead' | 'reorder';
+  action: 'resize-start' | 'resize-end' | 'playhead' | 'reorder';
   sceneId?: string;
   startX: number;
   startPosition: number;  // In frames
@@ -1052,7 +1052,8 @@ export default function TimelinePanel({ projectId, userId, onClose }: TimelinePa
     // For keyboard shortcuts, add confirmation
     if (!skipConfirmation) {
       const sceneIndex = scenes.findIndex((s: any) => s.id === sceneId);
-      const sceneName = scenes[sceneIndex]?.name || scenes[sceneIndex]?.data?.name || `Scene ${sceneIndex + 1}`;
+      const sceneData = scenes[sceneIndex] as any;
+      const sceneName = sceneData?.name || sceneData?.data?.name || `Scene ${sceneIndex + 1}`;
       if (!window.confirm(`Delete "${sceneName}"?\n\nPress OK to delete, or Cancel to keep it.`)) {
         return;
       }
@@ -1352,6 +1353,7 @@ export default function TimelinePanel({ projectId, userId, onClose }: TimelinePa
         let start = 0;
         for (let i = 0; i < scenes.length; i++) {
           const s = scenes[i];
+          if (!s) continue;
           const end = start + (s.duration || 150);
           if (currentFrame >= start && currentFrame < end) {
             return { scene: s, index: i, start };


### PR DESCRIPTION
… fixes

What I changed in auto-fix

- Always pass the correct scene:
    - Before queuing, validates the sceneId exists in the current storyboard and looks like a UUID.
    - Calls generateScene with userContext.sceneId, so the Brain reliably targets the correct scene.
- Force edit intent:
    - The prompt header now explicitly says to use the EDIT tool with targetSceneId=<uuid> and not to create a new scene.
- Richer context:
    - Embeds the broken scene code (full) in a fenced tsx block.
    - Includes neighbor context: full code for (n−1) and (n+1) if available.
    - Adds the error message, then a concise instruction based on attempt number.

Impact

- The Brain can reliably pick editScene on the correct target.
- The LLM sees the exact code to fix plus immediate continuity context.
- We still retain all safety rails (debounce, rate limiting, circuit breaker, duplicate‑signature checks)

Also includes Timeline panel fixes:
- Removed unused 'move' action from DragInfo type
- Fixed TypeScript errors with scene property access
- Added null checks for scene array iteration
- Improved click-to-select functionality on scene blocks