### PR TITLE
Fix scene name preservation during edit operations

### DIFF
--- a/src/generated/entities.ts
+++ b/src/generated/entities.ts
@@ -2,7 +2,7 @@
  * THIS FILE IS AUTO-GENERATED FROM DATABASE SCHEMA
  * DO NOT EDIT MANUALLY - RUN: npm run generate:types
  * 
- * Generated at: 2025-09-10T11:43:42.625Z
+ * Generated at: 2025-09-10T12:05:13.352Z
  */
 
 /**

--- a/src/server/api/routers/generation/helpers.ts
+++ b/src/server/api/routers/generation/helpers.ts
@@ -387,6 +387,7 @@ export async function executeToolFromDecision(
         requestedDurationFrames: decision.toolContext.requestedDurationFrames, // ADD THIS
         sceneId: decision.toolContext.targetSceneId,
         tsxCode: sceneToEdit.tsxCode, // ✓ Fixed: Using correct field name
+        sceneName: sceneToEdit.name, // Pass current scene name to preserve it
         currentDuration: sceneToEdit.duration,
         imageUrls: decision.toolContext.imageUrls,
         videoUrls: decision.toolContext.videoUrls,
@@ -418,6 +419,7 @@ export async function executeToolFromDecision(
       // Preserve manual trims by default: ONLY change duration if explicitly requested
       const setFields: any = {
         tsxCode: editResult.data.tsxCode,
+        name: editResult.data.name || sceneToEdit.name, // Preserve scene name
         props: editResult.data.props || sceneToEdit.props,
         updatedAt: new Date(),
       };

--- a/src/tools/edit/edit.ts
+++ b/src/tools/edit/edit.ts
@@ -327,6 +327,7 @@ Please edit the code according to the user request. Return the complete modified
       return {
         success: true,
         tsxCode: parsed.code,
+        name: input.sceneName, // Preserve the scene name
         duration: parsed.newDurationFrames || undefined,
         reasoning: parsed.reasoning || `Applied edit: ${input.userPrompt}`,
         chatResponse: parsed.reasoning || `I've updated the scene as requested`,

--- a/src/tools/helpers/types.ts
+++ b/src/tools/helpers/types.ts
@@ -116,6 +116,7 @@ export interface AddToolOutput extends BaseToolOutput {
 export interface EditToolInput extends BaseToolInput {
   sceneId: string;       // Just for reference
   tsxCode: string;       // ✓ FIXED: Was existingCode
+  sceneName?: string;    // Current scene name to preserve
   currentDuration?: number;
   imageUrls?: string[];
   videoUrls?: string[];
@@ -153,6 +154,7 @@ export interface EditToolInput extends BaseToolInput {
 
 export interface EditToolOutput extends BaseToolOutput {
   tsxCode: string;       // Updated code
+  name?: string;         // Scene name (preserved from input)
   duration?: number;     // Only if changed
   props?: Record<string, any>;
   changesApplied?: string[];


### PR DESCRIPTION
- Added sceneName field to EditToolInput and name field to EditToolOutput
- Modified Edit tool to preserve and return the scene name
- Updated generation router to pass scene name to edit tool and preserve it in database
- Fixes issue where scene names were changing to 'Animation' on every edit iteration