### PR TITLE
Timeline: fix scene reordering UX and reduce sensitivity

### DIFF
--- a/memory-bank/sprints/sprint116_images/progress.md
+++ b/memory-bank/sprints/sprint116_images/progress.md
@@ -14,3 +14,10 @@ Date: 2025-09-08 (later)
 - Added modular prompt base (technical guardrails) and mode deltas (embed/recreate); wired into AddTool and EditTool.
 - Updated README/design to reflect current status and modular assembly.
 - Expanded TODO with detailed, file-level tickets and acceptance criteria for Brain, ContextBuilder, tools, and deletion plan.
+
+Date: 2025-09-10
+- Timeline: fixed scene reordering UX to be deliberate, not over‑sensitive.
+  - Added press‑and‑hold (250ms) on scene block to initiate reorder (keeps drag‑to‑chat intact).
+  - Added small movement threshold during hold to avoid accidental activation.
+  - Widened drop acceptance band to center 25–75% of target scene for reliable drop.
+  - Persist reorder to DB via `scenes.reorderScenes` and keep Zustand + Preview in sync.

--- a/src/generated/entities.ts
+++ b/src/generated/entities.ts
@@ -2,7 +2,7 @@
  * THIS FILE IS AUTO-GENERATED FROM DATABASE SCHEMA
  * DO NOT EDIT MANUALLY - RUN: npm run generate:types
  * 
- * Generated at: 2025-09-10T11:43:42.625Z
+ * Generated at: 2025-09-10T13:22:04.208Z
  */
 
 /**


### PR DESCRIPTION
- Add press-and-hold (250ms) to initiate reorder on block
- Prevent native HTML5 drag from hijacking when reordering
- Cancel long-press if chat drag starts; keep drag-to-chat intact
- Require 25–75% center overlap to commit swap
- Update sprint116 progress log