### PR TITLE
Add Sprint 140 mobile planning docs

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,10 @@
 # 🏆 Bazaar-Vid Progress Summary
 
+## 📝 Latest Update (Sep 25, 2025)
+- Sprint 140: Opened "Mobile Experience Overhaul" with objectives, success metrics, and workstreams covering marketing funnel, workspace ergonomics, and instrumentation improvements.【F:memory-bank/sprints/sprint140_mobile/README.md†L1-L28】
+- Logged comprehensive mobile opportunity outline spanning foundation, landing page, generate workspace, and rollout plan to guide implementation.【F:memory-bank/sprints/sprint140_mobile/mobile-experience-outline.md†L1-L93】
+- Seeded sprint TODO + progress logs to coordinate planning and upcoming design/engineering tasks.【F:memory-bank/sprints/sprint140_mobile/TODO.md†L1-L32】【F:memory-bank/sprints/sprint140_mobile/progress.md†L1-L10】
+
 ## 📝 Latest Update (Sep 24, 2025)
 - Sprint 110: Stood up UTM attribution sprint docs (`memory-bank/sprints/sprint110_utm/`) detailing client capture, signed cookie + NextAuth persistence, reporting SQL, success metrics (95% coverage), and staging-first rollout plan.
 - Sprint 110: Implemented attribution capture/ingest stack (client capture, signed cookie HMAC helpers, `/api/attribution/{capture,ingest}`, `user_attribution` schema + SQL migration with backfill) without touching auth critical path.

--- a/memory-bank/sprints/sprint140_mobile/README.md
+++ b/memory-bank/sprints/sprint140_mobile/README.md
@@ -1,0 +1,24 @@
+# Sprint 140 – Mobile Experience Overhaul
+
+## Why this sprint exists
+- The landing page (`src/app/(marketing)/home/page.tsx`) is heavily tuned for desktop hero animations, long-form marketing copy, and large CTA buttons that do not adapt gracefully to smaller screens. The current implementation relies on manual `window.innerWidth` checks and spreads hero content in stacked blocks that create long scrolls on phones.【F:src/app/(marketing)/home/page.tsx†L1-L124】
+- The generate workspace swaps to `MobileWorkspaceLayout` and a bottom navigation bar, but it still mirrors the desktop mental model. Preview sizing is fixed, panel transitions are abrupt, and essential actions like timeline edits or render/export management become hidden on mobile devices.【F:src/app/projects/[id]/generate/workspace/GenerateWorkspaceRoot.tsx†L1-L211】【F:src/app/projects/[id]/generate/workspace/MobileWorkspaceLayout.tsx†L1-L118】
+
+## Sprint objective
+Deliver a mobile-first experience that keeps users in flow from marketing touch through project creation. We will:
+1. **Reduce friction on the marketing funnel** by creating responsive hero, proof, and CTA patterns that feel native on phones.
+2. **Rebuild the generate workspace for touch** so chat, preview, timeline, and library tools are easy to access without desktop assumptions.
+3. **Establish mobile instrumentation & QA** to ensure changes improve conversion and in-app task completion.
+
+## Success metrics
+- +15% lift in mobile sign-up → project creation conversion (baseline: TBD via analytics export).
+- Mobile workspace retention: ≥60% of mobile sessions trigger at least one generation within 2 minutes.
+- Zero mobile-only regressions in preview playback, chat input, or project switching (tracked via QA checklist and bug bash doc).
+
+## Workstreams
+1. **Foundation** – breakpoints, layout primitives, shared mobile components, loading/perf improvements.
+2. **Landing page** – hero, CTA stack, social proof, comparison modules, pricing CTA, FAQ accordion.
+3. **Generate workspace** – navigation, preview ergonomics, chat usability, attachments, timeline accessibility, template browsing, rendering/export controls.
+4. **Instrumentation & QA** – analytics dashboard, session replay sampling, device matrix, regression suites.
+
+See `mobile-experience-outline.md` for detailed ideas and `TODO.md` for actionable tickets.

--- a/memory-bank/sprints/sprint140_mobile/TODO.md
+++ b/memory-bank/sprints/sprint140_mobile/TODO.md
@@ -1,0 +1,26 @@
+# TODO — Sprint 140 Mobile
+
+## Foundation
+- [ ] Audit existing breakpoint usage and replace manual `window.innerWidth` checks with shared hook across marketing + workspace.
+- [ ] Create mobile UI primitive library (`BottomSheet`, `StickyCTA`, `FloatingActionBar`, responsive typography scale).
+- [ ] Implement lazy loading + `sizes` metadata for heavy marketing media assets.
+
+## Landing Page
+- [ ] Redesign hero for mobile-first stack with sticky CTA + social proof.
+- [ ] Convert long-form sections into swipeable card carousel with animation triggers.
+- [ ] Rework template/demo modules for horizontal scroll and capture engagement analytics.
+- [ ] Launch testimonial carousel + mobile-friendly FAQ accordion.
+
+## Generate Workspace
+- [ ] Redesign mobile navigation (bottom nav, floating quick actions, header switcher).
+- [ ] Enhance preview ergonomics (collapsible, pinch zoom, full-screen modal, thumb-friendly controls).
+- [ ] Upgrade chat composer with attachments, suggestions, and keyboard-safe layout.
+- [ ] Modernize templates/media/my-projects flows for mobile interactions.
+- [ ] Build mobile timeline drawer with scene reordering + audio summary.
+- [ ] Create dedicated mobile share/export flow with resilient error handling.
+
+## Instrumentation & QA
+- [ ] Extend analytics events for mobile funnel and workspace usage.
+- [ ] Configure session replay sampling + device tagging.
+- [ ] Draft regression checklist + usability testing plan.
+- [ ] Gate workspace changes behind `mobile_v2` flag and define rollout KPIs.

--- a/memory-bank/sprints/sprint140_mobile/mobile-experience-outline.md
+++ b/memory-bank/sprints/sprint140_mobile/mobile-experience-outline.md
@@ -1,0 +1,69 @@
+# Mobile Experience Outline — Sprint 140
+
+## 1. Foundation & Infrastructure
+- **Breakpoint audit & consolidation**
+  - Replace bespoke `window.innerWidth` checks on marketing pages with shared `useBreakpoint` hook to keep SSR-friendly logic and reduce hydration flicker.【F:src/app/(marketing)/home/page.tsx†L1-L47】
+  - Document standardized breakpoints (xs < 480, sm < 640, md < 768, etc.) and migrate Tailwind classes accordingly.
+- **Shared mobile primitives**
+  - Build `BottomSheet`, `StickyCTA`, and `FloatingActionBar` components for reuse across marketing and workspace surfaces.
+  - Extract responsive typography scale so hero headings and chat labels auto-adjust rather than relying on `text-3xl md:text-4xl` duplication.
+- **Performance safeguards**
+  - Lazy-load heavy marketing modules (e.g., YouTube iframe, template carousel) only when scrolled into view.
+  - Add image `sizes` attributes and responsive source sets for hero imagery and backgrounds.
+
+## 2. Landing Page Upgrades
+- **Hero section**
+  - Swap the two-column desktop layout for a stacked mobile hero with primary CTA + secondary social proof above the fold.
+  - Introduce auto-resizing CTA button that pins above the keyboard when login modal is open.
+  - Replace static gradient button container with `sticky` CTA bar when user scrolls past hero.
+- **Value proposition cards**
+  - Reflow text-heavy sections ("Create viral videos" and long paragraphs) into swipeable cards with iconography to prevent cognitive overload.【F:src/app/(marketing)/home/page.tsx†L74-L160】
+  - Use `IntersectionObserver` to trigger subtle animations instead of always-on particle effects on low-power devices.
+- **Template & demo modules**
+  - Convert template grid into horizontal scroll snaps with previews sized for phone width.
+  - For embedded demo video, surface a play overlay with analytics to capture engagement and degrade gracefully when autoplay is blocked.
+- **Trust & FAQ**
+  - Introduce compact testimonial carousel with avatar + quote sized for 320px width.
+  - Collapse FAQ into accordions with default-open first item, ensuring tap targets ≥48px.
+- **Analytics**
+  - Track `homepage_mobile_cta_click`, `homepage_mobile_scroll_depth`, and `homepage_mobile_video_play` events.
+  - Add pixel-perfect screenshots for QA on key breakpoints (320, 375, 414, 480, 600).
+
+## 3. Generate Workspace Enhancements
+- **Navigation & wayfinding**
+  - Replace bottom nav buttons with icons + labels that persist highlight, and add haptic feedback via `navigator.vibrate` fallback.
+  - Introduce floating "quick action" (generate, preview full-screen, timeline) button cluster that appears after first prompt.
+  - Add breadcrumbs / project switcher accessible from header without leaving workspace.
+- **Preview experience**
+  - Make preview panel collapsible with pinch-to-zoom and orientation-aware aspect ratios (lock to `min(80vh, width * aspect)` instead of fixed pixel heights).【F:src/app/projects/[id]/generate/workspace/MobileWorkspaceLayout.tsx†L61-L118】
+  - Provide full-screen preview modal with scrubber and caption for scene metadata.
+  - Surface playback controls optimized for thumb reach (bottom-right area).
+- **Chat & prompt input**
+  - Implement sticky composer with safe-area padding, quick-attach buttons (image, screen recording), and voice input toggle.
+  - Add prompt suggestions chips above composer that adapt to context (empty project, revision loop).
+  - Ensure keyboard interactions do not collapse preview unexpectedly; add `ScrollView` that keeps last messages visible.
+- **Templates & media library**
+  - Convert template list into category tabs with virtualization to avoid long scrolls.
+  - Provide search + filters in bottom sheet overlay to keep list accessible while preview remains visible.
+  - Sync `My Projects` with quick rename and swipe-to-switch interactions.
+- **Timeline & editing**
+  - Create mobile timeline drawer accessible via floating FAB; show scene cards stacked vertically with drag handles.
+  - Support long-press reorder and quick duration adjustments with slider controls.
+  - Add audio track summary and simple toggle to mute/unmute preview.
+- **Render & export**
+  - Add dedicated "Share/Export" screen optimized for mobile with progress indicator, share sheet integration, and ability to copy links.
+  - Provide offline-friendly error states when render queue fails (retry banner).
+
+## 4. Instrumentation, QA & Rollout
+- **Analytics dashboards**
+  - Break down mobile vs desktop funnel metrics in existing analytics tooling; annotate release milestones.
+  - Capture panel usage telemetry (chat vs templates vs projects) for mobile to prioritize follow-up iterations.
+- **Session replay & logging**
+  - Enable targeted session replay sampling (5% of mobile sessions) with masking for sensitive content.
+  - Extend existing `analytics.projectOpened` events with device info for correlation.【F:src/app/projects/[id]/generate/page.tsx†L1-L68】
+- **QA matrix**
+  - Define regression checklist covering iOS Safari, Android Chrome, small tablets, and desktop responsive mode.
+  - Schedule usability tests with 5 target customers; document insights in sprint progress notes.
+- **Rollout plan**
+  - Behind feature flag (`mobile_v2`) for workspace, with gradual ramp based on stability KPIs.
+  - Marketing changes ship globally after staging sign-off and Lighthouse mobile score ≥90.

--- a/memory-bank/sprints/sprint140_mobile/progress.md
+++ b/memory-bank/sprints/sprint140_mobile/progress.md
@@ -1,0 +1,10 @@
+# Progress — Sprint 140 Mobile
+
+## 2025-09-25
+- Created sprint folder with overview, outline, and TODO to consolidate mobile roadmap.
+- Captured current landing page + workspace gaps referencing existing implementations for context.
+- Defined success metrics, workstreams, and instrumentation requirements ahead of design/engineering kick-off.
+
+Next:
+- Validate baseline analytics for mobile funnel and workspace usage.
+- Draft wireframes for mobile hero, chat composer, and timeline drawer concepts.


### PR DESCRIPTION
## Summary
- establish Sprint 140 mobile experience folder with goals, metrics, and workstreams
- outline detailed landing page and generate workspace improvements for mobile
- seed TODO and progress tracking entries and update global progress log

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5121fbdf483278347f592a06c6fb6