### PR TITLE
Refresh mobile workspace navigation & project switcher

### DIFF
--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,5 +1,10 @@
 # 🏆 Bazaar-Vid Progress Summary
 
+## 📝 Latest Update (Sep 26, 2025)
+- Sprint 140: Implemented mobile navigation overhaul—bottom nav state persists per project with haptic feedback, quick actions for generate/preview/timeline, and documented approach in the navigation analysis.【F:src/app/projects/[id]/generate/workspace/MobileWorkspaceLayout.tsx†L1-L233】【F:memory-bank/sprints/sprint140_mobile/navigation-wayfinding-analysis.md†L1-L33】
+- Added floating timeline drawer and fullscreen preview quick action to keep mobile workflows thumb-friendly after the first prompt.【F:src/app/projects/[id]/generate/workspace/MobileWorkspaceLayout.tsx†L134-L210】
+- Delivered breadcrumb-driven project switcher across desktop and mobile headers so projects can be swapped in place without leaving the workspace.【F:src/components/AppHeader.tsx†L1-L239】【F:src/components/MobileAppHeader.tsx†L1-L233】【F:memory-bank/sprints/sprint140_mobile/progress.md†L12-L25】
+
 ## 📝 Latest Update (Sep 25, 2025)
 - Sprint 140: Opened "Mobile Experience Overhaul" with objectives, success metrics, and workstreams covering marketing funnel, workspace ergonomics, and instrumentation improvements.【F:memory-bank/sprints/sprint140_mobile/README.md†L1-L28】
 - Logged comprehensive mobile opportunity outline spanning foundation, landing page, generate workspace, and rollout plan to guide implementation.【F:memory-bank/sprints/sprint140_mobile/mobile-experience-outline.md†L1-L93】

--- a/memory-bank/sprints/sprint140_mobile/TODO.md
+++ b/memory-bank/sprints/sprint140_mobile/TODO.md
@@ -12,7 +12,7 @@
 - [ ] Launch testimonial carousel + mobile-friendly FAQ accordion.
 
 ## Generate Workspace
-- [ ] Redesign mobile navigation (bottom nav, floating quick actions, header switcher).
+- [x] Redesign mobile navigation (bottom nav, floating quick actions, header switcher).
 - [ ] Enhance preview ergonomics (collapsible, pinch zoom, full-screen modal, thumb-friendly controls).
 - [ ] Upgrade chat composer with attachments, suggestions, and keyboard-safe layout.
 - [ ] Modernize templates/media/my-projects flows for mobile interactions.

--- a/memory-bank/sprints/sprint140_mobile/navigation-wayfinding-analysis.md
+++ b/memory-bank/sprints/sprint140_mobile/navigation-wayfinding-analysis.md
@@ -1,0 +1,31 @@
+# Navigation & Wayfinding Updates — Sprint 140
+
+## Objectives
+- Persistent mobile bottom navigation highlighting even after layout reflows or project switches.
+- Tactile feedback for all primary mobile navigation actions.
+- Contextual quick actions to keep generation, preview, and timeline access within thumb reach once the user is active.
+- Breadcrumb-driven project switcher that works on both desktop and mobile headers without ejecting from the workspace.
+
+## Key Decisions
+1. **State persistence for bottom nav**
+   - Store the active panel key in `localStorage` per project (`bazaar:workspace:<id>:mobile-panel`).
+   - Reset to chat when the project changes to avoid confusing carry-over between projects.
+
+2. **Haptics abstraction**
+   - Added a single `triggerHaptic` helper that prefers `navigator.vibrate` and gracefully no-ops when unavailable (Safari, desktop).
+   - Reused the helper for nav taps, quick actions, and the quick-create flow so the feedback is consistent.
+
+3. **Quick action cluster**
+   - Anchored as a fixed stack above the bottom nav with blur + shadow to preserve preview visibility.
+   - Actions: `Generate` (switch to chat), `Full preview` (requests fullscreen on the preview container, with `webkitRequestFullscreen` fallback), `Timeline` (opens a modal drawer with the existing timeline panel via dynamic import to avoid initial bundle cost).
+   - Drawer closes on explicit close button or when the timeline panel fires `onClose`.
+
+4. **Breadcrumb switcher**
+   - Desktop (`AppHeader`) and mobile (`MobileAppHeader`) now show `Projects / Current` with a dropdown trigger when multiple projects are available.
+   - Switching closes the timeline and uses `router.push` to stay within the workspace route.
+   - Dropdown lists every project with a checkmark on the active one for clarity.
+
+## Follow-ups / Open Questions
+- Decide whether the timeline drawer should remember its open state or always require manual trigger.
+- Consider focusing the chat textarea when the `Generate` quick action is tapped (would need an event bridge to `ChatPanelG`).
+- Evaluate analytics hooks for quick action usage once mobile instrumentation stories are ready.

--- a/memory-bank/sprints/sprint140_mobile/progress.md
+++ b/memory-bank/sprints/sprint140_mobile/progress.md
@@ -8,3 +8,12 @@
 Next:
 - Validate baseline analytics for mobile funnel and workspace usage.
 - Draft wireframes for mobile hero, chat composer, and timeline drawer concepts.
+
+## 2025-09-26
+- Implemented mobile navigation overhaul: bottom nav state now persists per project with haptic feedback and quick action cluster post-generation. Linked implementation details in `navigation-wayfinding-analysis.md`.
+- Added floating timeline drawer and fullscreen preview trigger to keep post-generation actions within thumb reach.
+- Delivered breadcrumb-driven project switcher across desktop and mobile headers so users can swap projects in-place without leaving the workspace.
+
+Next:
+- Evaluate chat input focus hand-off from quick actions to further reduce taps.
+- Add analytics events for quick action + breadcrumb interactions once instrumentation workstream is ready.

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 import { useState } from "react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
-import { DownloadIcon, LogOutIcon, CheckIcon, XIcon, ShareIcon, Copy, Loader2, Layers } from "lucide-react";
+import { DownloadIcon, LogOutIcon, CheckIcon, XIcon, ShareIcon, Copy, Loader2, Layers, ChevronDown, FolderIcon } from "lucide-react";
 import { signOut } from "next-auth/react";
 import {
   DropdownMenu,
@@ -59,6 +59,9 @@ interface AppHeaderProps {
   user?: { name: string; email?: string; isAdmin?: boolean };
   projectId?: string;
   onCreateTemplate?: () => void;
+  projects?: { id: string; name: string }[];
+  currentProjectId?: string;
+  onProjectSwitch?: (projectId: string) => void;
 }
 
 export default function AppHeader({
@@ -70,12 +73,22 @@ export default function AppHeader({
   user,
   projectId,
   onCreateTemplate,
+  projects,
+  currentProjectId,
+  onProjectSwitch,
 }: AppHeaderProps) {
   const [isEditingName, setIsEditingName] = useState(false);
   const [newTitle, setNewTitle] = useState(projectTitle || "");
   const [isSharing, setIsSharing] = useState(false);
   const [renderId, setRenderId] = useState<string | null>(null);
   const [hasDownloaded, setHasDownloaded] = useState(false);
+  const currentProjectName = projects?.find((p) => p.id === currentProjectId)?.name;
+  const canSwitchProjects = Boolean(onProjectSwitch && projects && projects.length > 0);
+
+  const handleProjectSwitch = React.useCallback((targetId: string) => {
+    if (!onProjectSwitch) return;
+    onProjectSwitch(targetId);
+  }, [onProjectSwitch]);
 
   // Sync newTitle with projectTitle prop when it changes
   React.useEffect(() => {
@@ -341,7 +354,52 @@ export default function AppHeader({
       {/* Center: Project Title - Responsive */}
       <div className="flex-1 flex justify-center px-4 min-w-0">
         {projectTitle ? (
-          <div className="max-w-[280px] w-full flex justify-center min-w-0">
+          <div className="flex w-full max-w-[320px] flex-col items-center gap-1 min-w-0">
+            {canSwitchProjects ? (
+              <nav className="flex items-center gap-1 text-xs text-muted-foreground">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="flex items-center gap-1 rounded-full bg-gray-100/80 px-2 py-1 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-200"
+                      aria-label="Switch project"
+                    >
+                      <FolderIcon className="h-3 w-3" />
+                      Projects
+                      <ChevronDown className="h-3 w-3" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="center" className="w-56 max-h-64 overflow-y-auto rounded-[12px] border border-gray-100 shadow-lg">
+                    <DropdownMenuLabel className="text-xs font-medium text-gray-500">Switch project</DropdownMenuLabel>
+                    <DropdownMenuSeparator />
+                    {projects?.map((project) => (
+                      <DropdownMenuItem
+                        key={project.id}
+                        onClick={() => handleProjectSwitch(project.id)}
+                        className="flex items-center justify-between gap-2 text-xs"
+                      >
+                        <span className="truncate">{project.name}</span>
+                        {project.id === currentProjectId && <CheckIcon className="h-3 w-3 text-green-500" />}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <span>/</span>
+                <span
+                  className="max-w-[180px] truncate font-medium text-gray-700"
+                  title={currentProjectName || projectTitle}
+                >
+                  {currentProjectName || projectTitle}
+                </span>
+              </nav>
+            ) : (
+              <div className="text-xs text-muted-foreground">
+                Projects /
+                <span className="ml-1 font-medium text-gray-700" title={projectTitle}>
+                  {projectTitle}
+                </span>
+              </div>
+            )}
             {isEditingName ? (
               <div className="flex items-center w-full min-w-0">
                 <Input


### PR DESCRIPTION
## Summary
- persist mobile bottom navigation state per project, add haptic feedback, and surface quick actions plus a timeline drawer
- expose breadcrumb-driven project switcher across desktop and mobile headers to jump between projects without leaving the workspace
- document Sprint 140 navigation work and update sprint progress/TODO tracking

## Testing
- npm run lint *(fails: Node ran out of memory while executing `next lint` in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d516d968908327aca8041c750171d9