### PR TITLE
Fix ALL remaining soft-delete filter gaps

### DIFF
--- a/src/generated/entities.ts
+++ b/src/generated/entities.ts
@@ -2,7 +2,7 @@
  * THIS FILE IS AUTO-GENERATED FROM DATABASE SCHEMA
  * DO NOT EDIT MANUALLY - RUN: npm run generate:types
  * 
- * Generated at: 2025-10-01T13:56:33.886Z
+ * Generated at: 2025-10-01T19:16:56.462Z
  */
 
 /**

--- a/src/server/api/routers/generation/helpers.ts
+++ b/src/server/api/routers/generation/helpers.ts
@@ -529,7 +529,7 @@ export async function executeToolFromDecision(
       
       const [updatedScene] = await db.update(scenes)
         .set(setFields)
-        .where(eq(scenes.id, targetSceneIdForUpdate))
+        .where(and(eq(scenes.id, targetSceneIdForUpdate), isNull(scenes.deletedAt)))
         .returning();
       
       if (!updatedScene) {
@@ -616,7 +616,7 @@ export async function executeToolFromDecision(
           updatedAt: new Date(),
           revision: sql`${scenes.revision} + 1`,
         })
-        .where(eq(scenes.id, decision.toolContext.targetSceneId))
+        .where(and(eq(scenes.id, decision.toolContext.targetSceneId), isNull(scenes.deletedAt)))
         .returning();
       
       if (!trimmedScene) {


### PR DESCRIPTION
Addresses all 3 critical issues identified by Vercel review:

1. helpers.ts:532 - Added soft-delete guard to edit scene update
   - Prevents editing deleted scenes via chat
   - Now: .where(and(eq(scenes.id, targetSceneIdForUpdate), isNull(scenes.deletedAt)))

2. helpers.ts:619 - Added soft-delete guard to trim scene update
   - Prevents trimming deleted scenes via chat
   - Now: .where(and(eq(scenes.id, targetSceneId), isNull(scenes.deletedAt)))

3. helpers.ts:715-717 - Changed hard delete to soft delete (already done)
   - Consistent with scene-operations.ts pattern
   - Allows recovery via restore functionality

All scene update/delete operations now consistently check deletedAt, preventing deleted scenes from being accessible through any code path.